### PR TITLE
Close #18

### DIFF
--- a/egresos.html
+++ b/egresos.html
@@ -60,6 +60,6 @@
             </div>
         </nav>
     </div>
-    <iframe src="http://forma-urbana-egresos.herokuapp.com/apps/egresos" frameborder="0"></iframe> <!--Es una metapágina-->
+    <iframe src="https://forma-urbana-egresos.herokuapp.com/apps/egresos" frameborder="0"></iframe> <!--Es una metapágina-->
 </body>
 </html>

--- a/egresos.html
+++ b/egresos.html
@@ -60,6 +60,6 @@
             </div>
         </nav>
     </div>
-    <iframe src="http://forma-urbana-egresos.herokuapp.com/apps/denue" frameborder="0"></iframe> <!--Es una metapágina-->
+    <iframe src="http://forma-urbana-egresos.herokuapp.com/apps/egresos" frameborder="0"></iframe> <!--Es una metapágina-->
 </body>
 </html>

--- a/formaurbana.html
+++ b/formaurbana.html
@@ -60,6 +60,6 @@
             </div>
         </nav>
     </div>
-    <iframe src="http://forma-urbana-egresos.herokuapp.com/apps/denue" frameborder="0"></iframe> <!--Es una metapágina-->
+    <iframe src="https://forma-urbana-egresos.herokuapp.com/apps/denue" frameborder="0"></iframe> <!--Es una metapágina-->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -91,10 +91,10 @@
         <div class="uk-container">
             <h1 class="uk-article-title uk-text-bold">Gráficas</h1>
             <ul uk-tab uk-switcher="connect: .switcher-container">
-                <li><a href="">Población</a></li>
-                <li><a href="">Superficies</a></li>
-                <li><a href="">Densidad Poblacional</a></li>
-                <li><a href="">Costos</a></li>
+                <li><a href="#/">Población</a></li>
+                <li><a href="#/">Superficies</a></li>
+                <li><a href="#/">Densidad Poblacional</a></li>
+                <li><a href="#/">Costos</a></li>
             </ul>
 
             <ul class="uk-switcher switcher-container uk-margin">


### PR DESCRIPTION
Se solucionó un error que ocasionaba que al presionar el link en las pestañas de la sección de gráficas, la página se desplazara hacia arriba. Esto ocurre cuando se deja en blanco el atributo `href` de una etiqueta `a`, pues intenta simular que se vuelve a cargar la página. 

Esto puede solucionarse de la forma:
```html
<a href="#/">
```